### PR TITLE
Novos campos parametrizaveis para emissão de NFe

### DIFF
--- a/app/controllers/EmiteController.php
+++ b/app/controllers/EmiteController.php
@@ -110,7 +110,7 @@ class EmiteController extends ControllerBase
         $std->serie = 1; // série do documento fiscal
         $std->nNF = $_POST['numero']; // número do documento fiscal
         $std->dhEmi = date("c");; // data de emissão do documento fiscal
-        $std->dhSaiEnt = date("Y-m-d\TH:i:sP");; // data de saída ou da entrada da mercadoria / produto
+        $std->dhSaiEnt = date("c");; // data de saída ou da entrada da mercadoria / produto
         $std->tpNF = 1; // tipo de operação
         $std->idDest = 1;
         $std->cMunFG = $_POST['ibge_cidade']; //Código de município precisa ser válido

--- a/app/controllers/EmiteController.php
+++ b/app/controllers/EmiteController.php
@@ -64,7 +64,7 @@ class EmiteController extends ControllerBase
         $nfe->taginfNFe($std);
 
         $std = new stdObject();
-        $std->cUF = 53; //coloque um código real e válido
+        $std->cUF = substr($_POST['ibge_cidade'],0,2); //codigo ibge da UF será sempre os 2 primeiros digitos do ibge da cidade
         $std->cNF = '80070008'; //código numérico que compõe a chave de acesso
         $std->natOp = 'VENDA'; // descrição da natureza da operação
         $std->mod = 55; // código do modelo do documento fiscal
@@ -74,16 +74,16 @@ class EmiteController extends ControllerBase
         $std->dhSaiEnt = '2018-09-17T20:48:00-02:00'; // data de saída ou da entrada da mercadoria / produto
         $std->tpNF = 1; // tipo de operação
         $std->idDest = 1;
-        $std->cMunFG = 5300108; //Código de município precisa ser válido
+        $std->cMunFG = $_POST['ibge_cidade']; //Código de município precisa ser válido
         $std->tpImp = 1; // formato de impressão do DANFE
         $std->tpEmis = 1; // se informada a tag de tpemis=1 dhcont e xjust não devem ser informados, se informada dhcont e xjust devem ser informados.
-        $std->cDV = 2; // digito verificado da chave de acesso da nf-e
+        $std->cDV = 2; // digito verificado da chave de acesso da nf-e [TODO: precisa ser calculado corretamente]
         $std->tpAmb = 2; // Se deixar o tpAmb como 2 você emitirá a nota em ambiente de homologação(teste) e as notas fiscais aqui não tem valor fiscal
         $std->finNFe = 1; // finalidade de emissão da NF-e
-        $std->indFinal = 0; // ?
-        $std->indPres = 0; // ?
-        $std->procEmi = '0'; // processo de emissão da NF-e
-        $std->verProc = 1; // versão do processo de emissão da nf-e
+        $std->indFinal = 1; // Indica se esta NF-e foi emitida para Consumidor Final ou não ( por exemplo) para Revenda. 1 = Consumidor final
+        $std->indPres = 2; // Indiica se o destinatario da NF-e estava presente na emissão. 2 = Não presencial, pela internet
+        $std->procEmi = 0; // processo de emissão da NF-e. 0 = emissão de NF-e com aplicativo do contribuinte
+        $std->verProc = '1.0'; // versão do processo de emissão da nf-e
         $nfe->tagide($std);
 
         $std = new stdObject();
@@ -94,32 +94,31 @@ class EmiteController extends ControllerBase
         $nfe->tagemit($std);
 
         $std = new stdObject();
-        $std->xLgr = "Rua Teste"; // logradouro da empresa
-        $std->nro = '203'; // número
-        $std->xBairro = 'Centro'; // bairro
-        $std->cMun = 5300108; //Código de município precisa ser válido e igual o  cMunFG
-        $std->xMun = 'Bauru'; // nome do municipio
-        $std->UF = 'DF'; // sigla da uf
-        $std->CEP = '80045190'; // código do cep
+        $std->xLgr = $_POST['endereco']; // logradouro da empresa
+        $std->nro = $_POST['endereco_numero']; // número
+        $std->xBairro = $_POST['bairro']; // bairro
+        $std->cMun = $_POST['ibge_cidade']; //Código de município precisa ser válido e igual o  cMunFG
+        $std->xMun = $_POST['cidade']; // nome do municipio
+        $std->UF = 'DF'; // sigla da uf [TODO: Function que recebe um código IBGE de UF e retorna a sigla da mesma]
+        $std->CEP = $_POST['cep']; // código do cep
         $std->cPais = '1058'; // código do país
         $std->xPais = 'BRASIL'; // nome do país
         $nfe->tagenderEmit($std);
 
         $std = new stdObject();
-        $std->xNome = 'Empresa destinatário teste'; // razão social ou nome do destinatário
-        $std->indIEDest = 2; // ???
-        $std->IE = 'ISENTO'; //IE ??? campo de informação obrigatória nos casos de emissão própria (procEmi = 0,2 ou 3). A IE deve ser informada apenas com algarismos para destinatários contribuientes do ICMS, sem caracteres de formatação (ponto,barra,hifen, etc.); O literal "ISENTO" deve ser informado apenas para contribuintes do ICMS que são isentos de inscrição no cadastro de contribuintes do ICMS e estejam emitindo NF-e avulsa;
-        $std->CNPJ = '15236260000138'; // cnpj do destinatário ou cpf
+        $std->xNome = $_POST['destinatario']; // razão social ou nome do destinatário
+        $std->indIEDest = 9; // indica se é contribuinte ou não. PF sao sempre não contribuintes e PJ pode ser ambos. 9 = Não contribuinte
+        $std->CPF = $_POST['cpf_destinatario']; // cpf do destinatário
         $nfe->tagdest($std);
 
         $std = new stdObject();
-        $std->xLgr = "Rua Teste"; // logradouro da empresa destinatario
-        $std->nro = '203'; // numero da empresa destinatario
-        $std->xBairro = 'Centro'; // bairro da empresa destinatario
-        $std->cMun = '5300108'; // codigo do municipio
-        $std->xMun = 'Bauru'; // nome do municipio
-        $std->UF = 'DF'; // sigla da uf
-        $std->CEP = '80045190'; // código do cep
+        $std->xLgr = $_POST['endereco_destinatario']; // logradouro da empresa destinatario
+        $std->nro = $_POST['numero_endereco_destinatario']; // numero da empresa destinatario
+        $std->xBairro = $_POST['bairro_destinatario']; // bairro da empresa destinatario
+        $std->cMun = $_POST['ibge_cidade_destinatario']; // codigo do municipio
+        $std->xMun = $_POST['cidade_destinatario']; // nome do municipio
+        $std->UF = 'DF'; // sigla da uf [TODO: Function que receber um código IBGE de UF e retorna sigla da mesma]
+        $std->CEP = $_POST['cep_destinatario']; // código do cep
         $std->cPais = '1058'; // código do país
         $std->xPais = 'BRASIL'; // nome do país
         $nfe->tagenderDest($std);

--- a/app/controllers/EmiteController.php
+++ b/app/controllers/EmiteController.php
@@ -109,7 +109,7 @@ class EmiteController extends ControllerBase
         $std->mod = 55; // código do modelo do documento fiscal
         $std->serie = 1; // série do documento fiscal
         $std->nNF = $_POST['numero']; // número do documento fiscal
-        $std->dhEmi = date("Y-m-d\TH:i:sP");; // data de emissão do documento fiscal
+        $std->dhEmi = date("c");; // data de emissão do documento fiscal
         $std->dhSaiEnt = date("Y-m-d\TH:i:sP");; // data de saída ou da entrada da mercadoria / produto
         $std->tpNF = 1; // tipo de operação
         $std->idDest = 1;

--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -66,7 +66,7 @@
             </div>
             <div class="form-group">
                 <label for="country">CPF destinatário</label>
-                <input type="text" class="form-control" name="cpf_destinatario" placeholder="CPF" id="cpf">
+                <input type="text" class="form-control" name="cpf_destinatario" placeholder="CPF" id="cpf_destinatario">
             </div>
             <div class="form-group">
                 <label for="first-name">Endereço destinatário</label>

--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -91,7 +91,59 @@
             <div class="form-group">
                 <label for="first-name">CEP destinatário</label>
                 <input type="number" class="form-control" placeholder="CEP destinatário" name="cep_destinatario" id="cep_destinatario">
-            </div>            
+            </div>       
+            
+            <!-- Campos do produto-->
+            <div class="form-group">
+                <label for="first-name">Código Produto</label>
+                <input type="text" class="form-control" placeholder="Código do Produto" name="cod_produto" id="cod_produto">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">Nome Produto</label>
+                <input type="text" class="form-control" placeholder="Nome do Produto" name="nome_produto" id="nome_produto">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">NCM</label>
+                <input type="text" class="form-control" placeholder="NCM" name="ncm" id="ncm">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">Unidade Medida</label>
+                <input type="text" class="form-control" placeholder="Unidade de Medida" name="unidade_medida" id="unidade_medida">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">Quantidade</label>
+                <input type="text" class="form-control" placeholder="Quantidade" name="quantidade" id="quantidade">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">Valor Unitário</label>
+                <input type="text" class="form-control" placeholder="Valor unitário" name="valor_unitario" id="valor_unitario">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">CST</label>
+                <input type="text" class="form-control" placeholder="CST" name="cst" id="cst">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">CFOP</label>
+                <input type="text" class="form-control" placeholder="CFOP" name="cfop" id="cfop">
+            </div>   
+
+            <div class="form-group">
+                <label for="first-name">Aliquota ICMS (%)</label>
+                <input type="text" class="form-control" placeholder="Aliquota ICMS" name="aliq_icms" id="aliq_icms">
+            </div>  
+            <div class="form-group">
+                <label for="first-name">Aliquota PIS (%)</label>
+                <input type="text" class="form-control" placeholder="Aliquota PIS" name="aliq_pis" id="aliq_pis">
+            </div>  
+            <div class="form-group">
+                <label for="first-name">Aliquota COFINS (%)</label>
+                <input type="text" class="form-control" placeholder="Aliquota COFINS" name="aliq_cofins" id="aliq_cofins">
+            </div>  
+
+            <div class="form-group">
+                <label for="first-name">Valor Aprox. Tributos (Lei 12.741/12)</label>
+                <input type="text" class="form-control" placeholder="Valor Aprox. Tributos" name="valor_aprox_tributos" id="valor_aprox_tributos">
+            </div>   
 
             <div class="clearfix"></div>
             <button type="submit" class="btn btn-info btn-lg btn-responsive" id="search"> <span class="glyphicon glyphicon-send"></span> Emitir</button>

--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -23,6 +23,30 @@
                 <input type="text" class="form-control" name="cnpj" placeholder="CNPJ" id="cnpj">
             </div>
             <div class="form-group">
+                <label for="first-name">Endereço</label>
+                <input type="text" class="form-control" placeholder="Endereço" name="endereco" id="endereco">
+            </div>
+            <div class="form-group">
+                <label for="first-name">Nº endereço</label>
+                <input type="text" class="form-control" placeholder="Nº endereço" name="numero_endereco" id="numero_endereco">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">Bairro</label>
+                <input type="text" class="form-control" placeholder="Bairro" name="bairro" id="bairro">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">IBGE cidade</label>
+                <input type="number" class="form-control" placeholder="IBGE cidade" name="ibge_cidade" id="ibge_cidade">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">Nome cidade</label>
+                <input type="text" class="form-control" placeholder="Nome cidade" name="cidade" id="cidade">
+            </div>   
+            <div class="form-group">
+                <label for="first-name">CEP</label>
+                <input type="number" class="form-control" placeholder="CEP" name="cep" id="cep">
+            </div>            
+            <div class="form-group">
                 <label for="number">Certificado digital</label>
                 <input type="file" class="form-control"name="certificado" id="certificado">
             </div>
@@ -36,6 +60,39 @@
                 <input type="text" class="form-control" placeholder="Número da nota" name="numero" name="numero" id="numero">
             </div>
             
+            <div class="form-group">
+                <label for="first-name">Nome destinatário</label>
+                <input type="text" class="form-control" placeholder="Nome destinatário" name="nome_destinatario" id="nome_destinatario">
+            </div>
+            <div class="form-group">
+                <label for="country">CPF destinatário</label>
+                <input type="text" class="form-control" name="cpf_destinatario" placeholder="CPF" id="cpf">
+            </div>
+            <div class="form-group">
+                <label for="first-name">Endereço destinatário</label>
+                <input type="text" class="form-control" placeholder="Endereço destinatário" name="endereco_destinatario" id="endereco_destinatario">
+            </div>
+            <div class="form-group">
+                <label for="first-name">Nº endereço destinatário</label>
+                <input type="text" class="form-control" placeholder="Nº endereço" name="numero_endereco_destinatario" id="numero_endereco_destinatario">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">Bairro destinatário</label>
+                <input type="text" class="form-control" placeholder="Bairro destinatário" name="bairro_destinatario" id="bairro_destinatario">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">IBGE cidade destinatário</label>
+                <input type="number" class="form-control" placeholder="IBGE cidade destinatário" name="ibge_cidade_destinatario" id="ibge_cidade_destinatario">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">Nome cidade destinatário</label>
+                <input type="text" class="form-control" placeholder="Nome cidade destinatário" name="cidade_destinatario" id="cidade_destinatario">
+            </div>            
+            <div class="form-group">
+                <label for="first-name">CEP destinatário</label>
+                <input type="number" class="form-control" placeholder="CEP destinatário" name="cep_destinatario" id="cep_destinatario">
+            </div>            
+
             <div class="clearfix"></div>
             <button type="submit" class="btn btn-info btn-lg btn-responsive" id="search"> <span class="glyphicon glyphicon-send"></span> Emitir</button>
         </form>


### PR DESCRIPTION
Adicionados no front-end:
- Endereço do emitente
- Numero do endereço do emitente
- Bairro do emitente
- CEP do emitente
- IBGE da cidade do emitente
- Nome da cidade do emitente
- Endereço do destinatario
- Numero do endereço do destinatario
- Bairro do destinatario
- CEP do destinatario
- IBGE da cidade do destinatario
- Nome da cidade do destinatario
- CPF do destinatario
- Nome do destinatario
- Codigo do Produto
- Nome do Produto
- NCM
- Unidade de Medida
- Quantidade
- Valor Unitario
- CST
- CFOP
- Aliquota ICMS
- Aliquota PIS
- Aliquota COFINS
- Valor Aprox. Tributos

Documentado/Modificado no Controller (fora os campos do front-end):
- cUF
- cMunFG
- indFinal
- indPres
- procEmi (estava string, mas é int)
- verProc (estava int, mas é string)
- dhEmi
- dhSaiEnt
- cDV
- Removido tags de transporte (são apenas opcionais)
- Removido tags de Duplicata (Usa-se apenas quando pagamento é por duplicata mercantil)
- Removido tags de IPI, apenas industrias utilizam as mesmas.